### PR TITLE
SK6812 is a WS2812 clone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ How quickly can you get up and running with the library?  Here's a simple blink 
 Here's a list of all the LED chipsets are supported.  More details on the led chipsets are included [on our wiki page](https://github.com/FastLED/FastLED/wiki/Chipset-reference)
 
 * Adafruit's DotStars - AKA the APA102
-* Adafruit's Neopixel - aka the WS2812B (also WS2811/WS2812/WS2813, also supported in lo-speed mode) - a 3 wire addressable led chipset
+* Adafruit's Neopixel - aka the WS2812B (also WS2811/WS2812/WS2813, also supported in lo-speed mode)(SK6812 is a clone of WS2812) - a 3 wire addressable led chipset
 * TM1809/4 - 3 wire chipset, cheaply available on aliexpress.com
 * TM1803 - 3 wire chipset, sold by radio shack
 * UCS1903 - another 3 wire led chipset, cheap


### PR DESCRIPTION
Apparently the SK6812 is a clone of WS2812 as said in (#373)[https://github.com/FastLED/FastLED/issues/373#issuecomment-261682267] by @kriegsman 

I thought about adding a binding for WS2812 as SK6812, but i have no idea where to start, since this is my first time doing anything with this project.

Maybe the idea of a binding for SK6812 is a bad idea if no direct support for this chipset is given, since it may cause some trouble. 

But what is not a bad idea is documenting the fact that SK6812 is a clone of a supported chipset (WS2812), indicating that it may not work perfectly, but if the clone is good enouth it should work flawlessly.